### PR TITLE
Adjustments for localnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /workdir
 node.env
+network-localnet.env

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,0 @@
-network-localnet.env

--- a/config/network-testnet.env
+++ b/config/network-testnet.env
@@ -1,5 +1,6 @@
 address_network=testnet
-chain_id=2481632
+parent_chain_id=314159
+subnet_chain_id=2481632
 subnet_id="/r314159/t410fxhurcl3in7vbb3l245noc3nace7il74t45js7sa"
 
 # parent chain contract addresses

--- a/config/node-default.env
+++ b/config/node-default.env
@@ -58,11 +58,11 @@ faucet_trusted_proxy_ips=
 prometheus_external_network=
 prometheus_bind_address=
 
-# === For testing and localnet
-
 # Docker network name that all services exposing HTTP services will join
 # They are: cometbft, ethapi, objects, faucet, and recall-s3
 http_external_network=
+
+# === For testing and localnet
 
 # External docker network name that must be used instead of a new isolated network.
 # Useful for testing.

--- a/config/node-default.env
+++ b/config/node-default.env
@@ -61,3 +61,7 @@ prometheus_bind_address=
 # Docker network name that all services exposing HTTP services will join
 # They are: cometbft, ethapi, objects, faucet, and recall-s3
 http_external_network=
+
+# External docker network name that must be used instead of a new isolated network.
+# Useful for testing.
+external_default_network=

--- a/config/node-default.env
+++ b/config/node-default.env
@@ -58,6 +58,8 @@ faucet_trusted_proxy_ips=
 prometheus_external_network=
 prometheus_bind_address=
 
+# === For testing and localnet
+
 # Docker network name that all services exposing HTTP services will join
 # They are: cometbft, ethapi, objects, faucet, and recall-s3
 http_external_network=
@@ -65,3 +67,5 @@ http_external_network=
 # External docker network name that must be used instead of a new isolated network.
 # Useful for testing.
 external_default_network=
+
+ethapi_bind_address=

--- a/config/services/cometbft.config.toml
+++ b/config/services/cometbft.config.toml
@@ -205,7 +205,7 @@ laddr = "tcp://0.0.0.0:26656"
 # Address to advertise to peers for them to dial. If empty, will use the same
 # port as the laddr, and will introspect on the listener to figure out the
 # address. IP and port are required. Example: 159.89.10.97:26656
-external_address = "$advertised_external_ip:$external_cometbft_port"
+external_address = "$cometbft_external_address"
 
 # Comma separated list of seed nodes to connect to
 seeds = ""

--- a/config/services/ipc.config.toml
+++ b/config/services/ipc.config.toml
@@ -2,7 +2,7 @@ keystore_path = "$keystore_path"
 
 # Filecoin Calibration
 [[subnets]]
-id = "/r314159"
+id = "/r${parent_chain_id}"
 
 [subnets.config]
 network_type = "fevm"

--- a/config/snippets/ethapi-port-mapping.yml
+++ b/config/snippets/ethapi-port-mapping.yml
@@ -1,0 +1,4 @@
+services:
+  ethapi:
+    ports:
+      - $ethapi_bind_address:8545

--- a/config/snippets/external-default-network.yml
+++ b/config/snippets/external-default-network.yml
@@ -1,0 +1,4 @@
+networks:
+  default:
+    name: $external_default_network
+    external: true

--- a/config/snippets/port-mapping.yml
+++ b/config/snippets/port-mapping.yml
@@ -1,0 +1,12 @@
+services:
+  cometbft:
+    ports:
+      - $host_bind_ip:$external_cometbft_port:26656
+
+  fendermint:
+    ports:
+      - $host_bind_ip:$external_fendermint_port:26655
+
+  iroh:
+    ports:
+      - $host_bind_ip:$external_iroh_port:11204/udp

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -80,8 +80,6 @@ services:
     command: >
       --config.file=/etc/prometheus/config.yml
       --storage.tsdb.retention.time=10m
-    ports:
-      - $prometheus_bind_address:9090
 
 networks:
   default:

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -7,8 +7,6 @@ services:
     restart: always
     volumes:
       - $workdir/cometbft:/cometbft
-    ports:
-      - $host_bind_ip:$external_cometbft_port:26656
     user: root
 
   fendermint:
@@ -19,8 +17,6 @@ services:
       - $workdir/fendermint:/data
     env_file:
       - $workdir/generated/fendermint.env
-    ports:
-      - $host_bind_ip:$external_fendermint_port:26655
 
   ethapi:
     image: $fendermint_image
@@ -47,8 +43,6 @@ services:
     environment:
       IROH_DATA_DIR: /data
       IROH_CONFIG_DIR: /etc/iroh
-    ports:
-      - $host_bind_ip:$external_iroh_port:11204/udp
 
   objects:
     image: $fendermint_image

--- a/run.sh
+++ b/run.sh
@@ -71,9 +71,8 @@ case ${cmd:-"none"} in
     # set -x
     cometbft_id=$(docker exec ${project_name}-cometbft-1 cometbft show-node-id)
     fendermint_id=$(docker exec ${project_name}-fendermint-1 fendermint key show-peer-id --public-key /data/keys/network.pk)
-    echo "cometbft API URL: https://${dns_api}:443"
-    echo "commetbft: $cometbft_id@${dns_api}:26656"
-    echo "fendermint: /dns/$dns_api/tcp/26655/p2p/$fendermint_id"
+    echo "cometbft_id: $cometbft_id"
+    echo "fendermint_id: $fendermint_id"
     ;;
 
   ipc-cli)

--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,7 @@ function set_compose_files {
     [ "$enable_faucet" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-faucet.yml"
     [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-recall-s3.yml"
   fi
+  [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
   export COMPOSE_FILE
 }
 
@@ -40,6 +41,7 @@ case ${cmd:-"none"} in
     
   init)
     export COMPOSE_FILE="./docker-compose.init.yml"
+    [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
     trap "docker compose down" EXIT
     docker compose build
     docker compose up --abort-on-container-failure

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ function set_compose_files {
     [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-recall-s3.yml"
   fi
   [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
+  [ ! -z "$ethapi_bind_address" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/ethapi-port-mapping.yml"
   export COMPOSE_FILE
 }
 

--- a/run.sh
+++ b/run.sh
@@ -20,6 +20,7 @@ function set_compose_files {
   fi
   [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
   [ ! -z "$ethapi_bind_address" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/ethapi-port-mapping.yml"
+  [ ! -z "$host_bind_ip" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/port-mapping.yml"
   export COMPOSE_FILE
 }
 

--- a/scripts/download-genesis.sh
+++ b/scripts/download-genesis.sh
@@ -31,8 +31,8 @@ function download_from_parent_chain {
 
   fendermint genesis --genesis-file $raw set-eam-permissions --mode unrestricted
   set +u
-  if [ ! -z "$chain_id" ]; then
-    fendermint genesis --genesis-file $raw set-chain-id --chain-id $chain_id
+  if [ ! -z "$subnet_chain_id" ]; then
+    fendermint genesis --genesis-file $raw set-chain-id --chain-id $subnet_chain_id
   fi
   set -u
 

--- a/scripts/write-configs.sh
+++ b/scripts/write-configs.sh
@@ -25,6 +25,9 @@ if [ "$cometbft_statesync_enable" == "true" ]; then
 else
   export trusted_block_height=0
 fi
+if [ ! -z "$advertised_external_ip" ]; then
+  export cometbft_external_address="$advertised_external_ip:$external_cometbft_port"
+fi
 
 envsubst < /repo/config/services/cometbft.config.toml > /workdir/cometbft/config/config.toml
 


### PR DESCRIPTION
This PR adds various adjustments for localnet deployment:
* Enable deploying all node components into an external docker network.
* Enable not to bind cometbft, fendermint and iroh addresses to the host IP (localnet is running inside a single docker network).
* Do not try to sync the state from cometbft peers if no snapshot has been made.