### PR TITLE
Expose ports required by recall-cli

### DIFF
--- a/config/node-default.env
+++ b/config/node-default.env
@@ -68,4 +68,5 @@ http_external_network=
 # Useful for testing.
 external_default_network=
 
-ethapi_bind_address=
+# If true, bind ports required by recall CLI on localhost
+localhost_bind_cli_ports=false

--- a/config/node-default.env
+++ b/config/node-default.env
@@ -68,5 +68,5 @@ http_external_network=
 # Useful for testing.
 external_default_network=
 
-# If true, bind ports required by recall CLI on localhost
-localhost_bind_cli_ports=false
+# Expose services required by recall CLI on the specified host
+localhost_cli_bind_host=

--- a/config/snippets/ethapi-port-mapping.yml
+++ b/config/snippets/ethapi-port-mapping.yml
@@ -1,4 +1,0 @@
-services:
-  ethapi:
-    ports:
-      - $ethapi_bind_address:8545

--- a/config/snippets/localnet-cli-port-mapping.yml
+++ b/config/snippets/localnet-cli-port-mapping.yml
@@ -1,12 +1,12 @@
 services:
   cometbft:
     ports:
-      - localhost:26657:26657
+      - $localhost_cli_bind_host:26657:26657
 
   ethapi:
     ports:
-      - localhost:8645:8545
+      - $localhost_cli_bind_host:8645:8545
 
   objects:
     ports:
-      - localhost:8001:8001
+      - $localhost_cli_bind_host:8001:8001

--- a/config/snippets/localnet-cli-port-mapping.yml
+++ b/config/snippets/localnet-cli-port-mapping.yml
@@ -1,0 +1,12 @@
+services:
+  cometbft:
+    ports:
+      - localhost:26657:26657
+
+  ethapi:
+    ports:
+      - localhost:8645:8545
+
+  objects:
+    ports:
+      - localhost:8001:8001

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ function set_compose_files {
     [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-recall-s3.yml"
   fi
   [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
-  [ "$localhost_bind_cli_ports" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/localnet-cli-port-mapping.yml"
+  [ ! -z "$localhost_cli_bind_host" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/localnet-cli-port-mapping.yml"
   [ ! -z "$host_bind_ip" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/port-mapping.yml"
   export COMPOSE_FILE
 }

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ function set_compose_files {
     [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-recall-s3.yml"
   fi
   [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"
-  [ ! -z "$ethapi_bind_address" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/ethapi-port-mapping.yml"
+  [ "$localhost_bind_cli_ports" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/localnet-cli-port-mapping.yml"
   [ ! -z "$host_bind_ip" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/port-mapping.yml"
   export COMPOSE_FILE
 }


### PR DESCRIPTION
This PR adds a configuration option to expose ports required by recall CLI.