### PR TITLE
Rename faucet to registrar

### DIFF
--- a/config/node-default.env
+++ b/config/node-default.env
@@ -12,7 +12,7 @@ cometbft_image="cometbft/cometbft:v0.37.x"
 iroh_image="n0computer/iroh:v0.28.1"
 recall_exporter_image="textilemachine/recall-exporter:sha-9beb26d"
 prometheus_image="prom/prometheus:v2.54.1"
-faucet_image="textilemachine/registrar:51b2636"
+registrar_image="textilemachine/registrar:51b2636"
 recall_s3_image="textilemachine/recall-s3:sha-46d5924"
 
 # Directory where all services store their data, like interval states, blocks, etc.
@@ -47,12 +47,12 @@ recall_s3_secret_key=
 recall_s3_domain=
 
 
-# Set to true if you want to run your own faucet service.
-enable_faucet=false
-# Optional unless enable_faucet=true
-faucet_owner_private_key=
-faucet_turnstile_secret_key=
-faucet_trusted_proxy_ips=
+# Set to true if you want to run your own registrar service.
+enable_registrar=false
+# Optional unless enable_registrar=true
+registrar_faucet_owner_private_key=
+registrar_turnstile_secret_key=
+registrar_trusted_proxy_ips=
 
 # Docker network name that prometheus will join
 prometheus_external_network=

--- a/config/services/faucet.env
+++ b/config/services/faucet.env
@@ -1,7 +1,0 @@
-PRIVATE_KEY="${faucet_owner_private_key:?}"
-FAUCET_ADDRESS="$subnet_faucet_contract_address"
-TRUSTED_PROXY_IPS=$faucet_trusted_proxy_ips
-EVM_RPC_URL="http://${project_name}-ethapi-1:8545"
-LISTEN_HOST="0.0.0.0"
-LISTEN_PORT="8080"
-TS_SECRET_KEY="${faucet_turnstile_secret_key:?}"

--- a/config/services/registrar.env
+++ b/config/services/registrar.env
@@ -1,0 +1,7 @@
+PRIVATE_KEY="${registrar_faucet_owner_private_key:?}"
+FAUCET_ADDRESS="$subnet_faucet_contract_address"
+TRUSTED_PROXY_IPS=$registrar_trusted_proxy_ips
+EVM_RPC_URL="http://${project_name}-ethapi-1:8545"
+LISTEN_HOST="0.0.0.0"
+LISTEN_PORT="8080"
+TS_SECRET_KEY="${registrar_turnstile_secret_key:?}"

--- a/config/snippets/faucet.yml
+++ b/config/snippets/faucet.yml
@@ -1,8 +1,0 @@
-services:
-  faucet:
-    image: $faucet_image
-    restart: always
-    env_file:
-      - $workdir/generated/faucet.env
-    depends_on:
-      - ethapi

--- a/config/snippets/http-network-registrar.yml
+++ b/config/snippets/http-network-registrar.yml
@@ -1,5 +1,5 @@
 services:
-  faucet:
+  registrar:
     networks:
       - default
       - external-http

--- a/config/snippets/registrar.yml
+++ b/config/snippets/registrar.yml
@@ -1,0 +1,8 @@
+services:
+  registrar:
+    image: $registrar_image
+    restart: always
+    env_file:
+      - $workdir/generated/registrar.env
+    depends_on:
+      - ethapi

--- a/run.sh
+++ b/run.sh
@@ -9,13 +9,13 @@ source ./scripts/read-config.sh
 function set_compose_files {
   COMPOSE_FILE=./docker-compose.run.yml
   [ "$enable_relayer" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/relayer.yml"
-  [ "$enable_faucet" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/faucet.yml"
+  [ "$enable_registrar" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/registrar.yml"
   [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/recall-s3.yml"
   [ ! -z "$prometheus_external_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/prometheus-network.yml"
   [ ! -z "$prometheus_bind_address" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/prometheus-port-mapping.yml"
   if [ ! -z "$http_external_network" ]; then
     COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network.yml"
-    [ "$enable_faucet" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-faucet.yml"
+    [ "$enable_registrar" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-registrar.yml"
     [ "$enable_recall_s3" == "true" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/http-network-recall-s3.yml"
   fi
   [ ! -z "$external_default_network" ] && COMPOSE_FILE="$COMPOSE_FILE:./config/snippets/external-default-network.yml"

--- a/scripts/write-configs.sh
+++ b/scripts/write-configs.sh
@@ -62,10 +62,10 @@ if [ $enable_relayer == "true" ]; then
   echo '[{"targets":["relayer:9184"]}]' > $prom_targets_dir/relayer.json
 fi
 
-if [ $enable_faucet == "true" ]; then
+if [ $enable_registrar == "true" ]; then
   export recall_exporter_subnet_faucet_contract_address=$subnet_faucet_contract_address
   # Uncomment when registrar implements prometheus metrics.
-  # echo '[{"targets":["faucet:9090"]}]' > $prom_targets_dir/faucet.json
+  # echo '[{"targets":["registrar:9090"]}]' > $prom_targets_dir/registrar.json
 fi
 
 if [ $enable_recall_s3 == "true" ]; then
@@ -89,5 +89,4 @@ write_env ethapi.env
 write_env objects.env
 write_env recall-exporter.env
 if [ $enable_recall_s3 == "true" ]; then write_env recall-s3.env; fi
-if [ $enable_faucet == "true" ]; then write_env faucet.env; fi
-
+if [ $enable_registrar == "true" ]; then write_env registrar.env; fi


### PR DESCRIPTION
This PR renames faucet service to registrar to match the github project name.

Close #18 