### PR TITLE
Do not set localhost_cli_bind_host

### DIFF
--- a/config/node-default.env
+++ b/config/node-default.env
@@ -69,4 +69,4 @@ http_external_network=
 external_default_network=
 
 # Expose services required by recall CLI on the specified host
-localhost_cli_bind_host=
+# localhost_cli_bind_host=


### PR DESCRIPTION
This PR avoids overwriting `localhost_cli_bind_host` that can be set in the parent environment.